### PR TITLE
feat:custom-headers-via-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
 # Termino-logistic
 
-## About
-
 Termino-logistic is a powerful command-line interface (CLI) tool written in Python that allows users to send HTTP requests effortlessly. It is designed to streamline API interactions by supporting request configurations via YAML and JSON files. With Termino-logistic, users can execute various HTTP methods, manage request headers, send query parameters, and handle responses with ease. This tool is ideal for developers and testers who frequently interact with APIs and require a lightweight yet flexible solution.
+
+## Table of Contents
+- [Termino-logistic](#termino-logistic)
+  - [Table of Contents](#table-of-contents)
+  - [How to use](#how-to-use)
+    - [Input Output Redirection](#input-output-redirection)
+    - [Sample request file `myrequest.yml`](#sample-request-file-myrequestyml)
+    - [A full example file `myrequest.yml`](#a-full-example-file-myrequestyml)
+  - [How to Set Up the Project](#how-to-set-up-the-project)
+    - [Clone the Repository in Your Local Environment](#clone-the-repository-in-your-local-environment)
+    - [Setting Up the Environment](#setting-up-the-environment)
+    - [Building and Uploading the Package](#building-and-uploading-the-package)
+      - [Explanation:](#explanation)
+      - [Understanding `setup.py`](#understanding-setuppy)
+  - [How to contribute to this project](#how-to-contribute-to-this-project)
+    - [How you can improve the project](#how-you-can-improve-the-project)
+    - [How to contribute by writing test cases](#how-to-contribute-by-writing-test-cases)
+    - [How to contribute by writing docs](#how-to-contribute-by-writing-docs)
+    - [Important notes](#important-notes)
+    - [How to raise an issue](#how-to-raise-an-issue)
+    - [How to submit a pull request](#how-to-submit-a-pull-request)
+    - [Branch Naming Convention](#branch-naming-convention)
+  - [Conclusion](#conclusion)
+  - [License](#license)
+
 
 ## How to use
 
@@ -19,6 +42,9 @@ termino -f request.json
 termino -f -c request.yml
 # example with using a json file
 termino -f -c request.json
+
+# Sending a GET request with custom headers (Note: this will override existing headers(if any) in .yml or .json file)
+termino -f request.yml -H "Authorization: Bearer mytoken" -H "User-Agent: CustomClient/1.0"
 ```
 
 ### Input Output Redirection

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from app.yeet import Yeeter
 def main():
     args = parse_args()
     yeeter = Yeeter(args.colorize)
-    yeeter.yeet(args.filepath)
+    yeeter.yeet(args.filepath, args.header)
 
 
 def parse_args():
@@ -33,6 +33,17 @@ def parse_args():
         help="Request filepath in .json or .yaml or .yml format",
     )
     ap.add_argument(
+        "-H",
+        "--header",
+        action="append",
+        help="Specify custom HTTP headers (use multiple times for multiple headers)",
+    )
+    ap.add_argument(
         "-c", "--colorize", action="store_true", help="colorize stdout and stderr"
     )
     return ap.parse_args()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/app/yeet.py
+++ b/app/yeet.py
@@ -57,8 +57,16 @@ class Yeeter:
             )
 
     # Sends an HTTP request based on the provided file and processes the response.
-    def yeet(self, request_filepath):
+    def yeet(self, request_filepath, headers: list[str]):        
         request_data: dict = read_request_file(request_filepath)
+        cli_headers_dict = {}
+        if headers:
+            for header in headers:
+                key, value = header.split(':', 1)
+                cli_headers_dict[key.strip().lower()] = value.strip()  
+        # Merge headers (CLI headers take precedence)
+        headers = {**{k.lower(): v for k, v in request_data["headers"].items()}, **cli_headers_dict}
+        request_data["headers"] = headers        
         response: Response = request(**request_data)
 
         metadata_text = json.dumps(


### PR DESCRIPTION
### Description
This Pull Request adds support for custom headers via CLI flags in the `termino-logistic` CLI tool. Users can now specify HTTP headers dynamically using the `-H` or `--header` option when running commands.

### Related Issue
[Issue #1: Add Support for Custom Headers via CLI Flags](https://github.com/debarshee2004/termino-logistic/issues/1)

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test case addition
- [ ] Other (please describe):

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Notes
This feature improves flexibility by allowing users to quickly modify headers without editing configuration files. It is useful for authentication (e.g., API keys, JWT tokens) where tokens may change frequently and enhances debugging and testing by allowing users to quickly test API responses with different headers.